### PR TITLE
Placenl patches 21 22

### DIFF
--- a/placenlbot.user.js
+++ b/placenlbot.user.js
@@ -14,6 +14,7 @@
 // @grant        GM_getResourceText
 // @grant        GM_addStyle
 // @grant        GM.xmlHttpRequest
+// @connect      https://reddit.com
 // ==/UserScript==
 
 var socket;

--- a/placenlbot.user.js
+++ b/placenlbot.user.js
@@ -13,6 +13,7 @@
 // @downloadURL  https://raw.githubusercontent.com/Skeeww/Bot/master/placenlbot.user.js
 // @grant        GM_getResourceText
 // @grant        GM_addStyle
+// @grant        GM.xmlHttpRequest
 // ==/UserScript==
 
 var socket;
@@ -354,8 +355,14 @@ async function getCurrentImageUrl(id = '0') {
 function getCanvasFromUrl(url, canvas, x = 0, y = 0, clearCanvas = false) {
     return new Promise((resolve, reject) => {
         let loadImage = ctx => {
+        GM.xmlHttpRequest({
+            method: "GET",
+            url: url,
+            responseType: 'blob',
+            onload: function(response) {
+            var urlCreator = window.URL || window.webkitURL;
+            var imageUrl = urlCreator.createObjectURL(this.response);
             var img = new Image();
-            img.crossOrigin = 'anonymous';
             img.onload = () => {
                 if (clearCanvas) {
                     ctx.clearRect(0, 0, canvas.width, canvas.height);
@@ -370,7 +377,9 @@ function getCanvasFromUrl(url, canvas, x = 0, y = 0, clearCanvas = false) {
                 }).showToast();
                 setTimeout(() => loadImage(ctx), 3000);
             };
-            img.src = url;
+            img.src = imageUrl;
+  }
+})
         };
         loadImage(canvas.getContext('2d'));
     });

--- a/placenlbot.user.js
+++ b/placenlbot.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         PlaceNL Bot Fork for France
 // @namespace    https://github.com/Skeeww/Bot
-// @version      30
+// @version      31
 // @description  FRANCE
 // @author       NoahvdAa (fork by Skew)
 // @match        https://www.reddit.com/r/place/*


### PR DESCRIPTION
Application des patches 21 et 22 venant de placenl
- 21: Fix de l'erreur CORS qui est apparue dans la soirée
- 22: Fix pour éviter de demander l'autorisation d'accéder à un domain en bypassant les CORS

Cette PR remplace ma précédente, j'avais trouvé la même solution qu'eux pour le soucis des CORS, mais mieux vaut appliquer leur patch pour éviter de trop diverger pour rien.